### PR TITLE
Revision 1

### DIFF
--- a/check-for-updates
+++ b/check-for-updates
@@ -1,8 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
-holderFile="$PWD/Updates.txt"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+holderFile="$DIR/Updates.txt"
 aptCheckFile="/usr/lib/update-notifier/apt-check"
-zeroUpdateFile="$PWD/zeroUpdates.txt"
+zeroUpdateFile="$DIR/zeroUpdates.txt"
 
 # Check for dependancies
 dependant() {

--- a/updater
+++ b/updater
@@ -1,7 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
-updateFile="$PWD/Updates.txt"
-updateChecker="$PWD/check-for-updates"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+updateFile="$DIR/Updates.txt"
+updateChecker="$DIR/check-for-updates"
 
 quit() {
 	printf "\nDone, thank you for using Updater\n\n"


### PR DESCRIPTION
Changed /bin/sh to /bin/bash because of a workaround for directory. I needed the directory to be the current directory of the script, not the directory it was called from. Added DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" as that was the only way I could figure this out. Until I can be bothered to write the program in a more robust language.